### PR TITLE
Reset counters when a packet expires.

### DIFF
--- a/templates/src/optimized/bootloader_uart_mips.c.ftl
+++ b/templates/src/optimized/bootloader_uart_mips.c.ftl
@@ -347,6 +347,8 @@ static void input_task(void)
     /* Check if 100 ms have elapsed */
     if (CORETIMER_CompareHasExpired())
     {
+        ptr = 0;
+        size = 0;
         header_received = false;
     }
 


### PR DESCRIPTION
If there's a gap of more than 100ms between characters the packet gets
abandonned but the counters were not reset so you can't retry because
the buffer gets out of sync.